### PR TITLE
Changing the Googlebot UA so tumblr RSS works again.

### DIFF
--- a/init.php
+++ b/init.php
@@ -135,7 +135,7 @@ class Tumblr_GDPR_UA extends Plugin
           'url' => $fetch_url,
           'login' => $auth_login,
           'pass' => $auth_pass,
-          'useragent' => 'googlebot');
+          'useragent' => 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)');
         return fetch_file_contents($options);
     }
 


### PR DESCRIPTION
Hi, this plugin only works for me if I change the user agent to match Google's user agent.  Issuing a pull request in case others have the same problem.